### PR TITLE
regardless of the self-cert chain check, check for len first

### DIFF
--- a/receipt.go
+++ b/receipt.go
@@ -56,6 +56,7 @@ var (
 // Need decode to DER binary if recevied a base64 file.
 func Parse(root *x509.Certificate, data []byte) (Receipts, error) {
 	pkcs, err := pkcs7.Parse(data)
+
 	if err != nil {
 		return Receipts{}, err
 	}
@@ -105,7 +106,7 @@ func verifyCertificates(root *x509.Certificate, certs []*x509.Certificate) bool 
 	for _, cert := range certs {
 		chain, err := cert.Verify(opts)
 		for _, c := range chain {
-			if c[0] == c[1] {
+			if len(c) > 1 && c[0] == c[1] {
 				// self certificate
 				return false
 			}


### PR DESCRIPTION
found a sandbox receipt that broke at this line with an index out of bounds, ugh.

this fixes [this issue](https://github.com/adityanatraj/iaplocal/issues/1)